### PR TITLE
chore(docs): polish docstrings and adopt Google style

### DIFF
--- a/labels.py
+++ b/labels.py
@@ -139,7 +139,7 @@ def create_labels_from_toml(file_path, repo, dry_run=False):
 
 def confirm_operation(repo, file_path):
     """
-    Prompt the user before executing the GitHub CLI command for modifying labels.
+    Prompts the user before executing the GitHub CLI command for modifying labels.
 
     Args:
         repo (str): GitHub repository name in owner/repo format.

--- a/labels.py
+++ b/labels.py
@@ -33,12 +33,9 @@ def run_gh_command(cmd, repo, dry_run=False):
     Executes a GitHub CLI command.
 
     Args:
-        cmd (list): Base gh CLI command, e.g. ['label', 'list']
-        repo (str): GitHub repository in the form owner/repo
-        dry_run (bool): If True, only prints the command
-
-    Returns:
-        str | None: Command output or None on failure
+        cmd (list): Base GitHub CLI command, e.g. ['label', 'list'].
+        repo (str): GitHub repository name in owner/repo format.
+        dry_run (bool): If True, runs the function in simulation mode.
     """
     full_cmd = ["gh"] + cmd + ["--repo", repo]
     if dry_run:
@@ -56,11 +53,11 @@ def run_gh_command(cmd, repo, dry_run=False):
 
 def backup_labels(repo, dry_run=False):
     """
-    Creates a TOML backup of the current label state.
+    Creates a TOML file backup of the current labels in the specified GitHub repository.
 
     Args:
-        repo (str): GitHub repository
-        dry_run (bool): If True, skip execution
+        repo (str): GitHub repository name in owner/repo format.
+        dry_run (bool): If True, runs the function in simulation mode.
     """
     if dry_run:
         logger.info("[DRY-RUN] Skipping label backup.")
@@ -95,11 +92,11 @@ def backup_labels(repo, dry_run=False):
 
 def delete_all_labels(repo, dry_run=False):
     """
-    Deletes all labels in the GitHub repository.
+    Deletes all labels in the specified repository.
 
     Args:
-        repo (str): GitHub repository
-        dry_run (bool): If True, simulate only
+        repo (str): GitHub repository name in owner/repo format.
+        dry_run (bool): If True, runs the function in simulation mode.
     """
     logger.info(f"🗑️  Fetching existing labels from {repo}...")
     output = run_gh_command(["label", "list"], repo, dry_run)
@@ -115,12 +112,12 @@ def delete_all_labels(repo, dry_run=False):
 
 def create_labels_from_toml(file_path, repo, dry_run=False):
     """
-    Reads TOML file and creates all defined labels.
+    Reads a TOML labels configuration file and uses the GitHub CLI to create labels in the specified repository.
 
     Args:
-        file_path (str): Path to label definition file
-        repo (str): GitHub repository
-        dry_run (bool): If True, simulate only
+        file_path (str): TOML file path containing label definitions, which can be relative or absolute.
+        repo (str): GitHub repository name in owner/repo format.
+        dry_run (bool): If True, runs the function in simulation mode.
     """
     logger.info(f"📄 Reading labels from: {file_path}")
     with open(file_path, "rb") as f:
@@ -142,14 +139,14 @@ def create_labels_from_toml(file_path, repo, dry_run=False):
 
 def confirm_operation(repo, file_path):
     """
-    Asks user to confirm potentially destructive changes.
+    Prompt the user before executing the GitHub CLI command for modifying labels.
 
     Args:
-        repo (str): GitHub repository
-        file_path (str): TOML label file
+        repo (str): GitHub repository name in owner/repo format.
+        file_path (str): TOML file path containing label definitions, which can be relative or absolute.
 
     Returns:
-        bool: True if user confirms
+        bool: Whether the user confirms the action.
     """
     logger.warning(f"You are about to modify labels in: {repo}")
     logger.info(f"Using label definitions from: {file_path}")
@@ -158,6 +155,12 @@ def confirm_operation(repo, file_path):
 
 
 def main():
+    """
+    CLI entry point for synchronizing GitHub labels from a TOML file.
+
+    Parses command-line arguments, configures logging and applies label changes
+    to the specified repository.
+    """
     parser = argparse.ArgumentParser(description="Sync GitHub labels from a TOML file.")
 
     parser.add_argument(

--- a/logger_setup.py
+++ b/logger_setup.py
@@ -25,7 +25,7 @@ logger.add(
 
 def _handle_exception(exc_type, exc_value, exc_traceback):
     """
-    Handles uncaught exceptions globally and logs them using loguru.
+    Handles uncaught exceptions registered via sys.excepthook and logs them using loguru.
     """
     if issubclass(exc_type, KeyboardInterrupt):
         sys.__excepthook__(exc_type, exc_value, exc_traceback)
@@ -38,10 +38,11 @@ sys.excepthook = _handle_exception
 
 def configure_console_logger(level: str = "INFO"):
     """
-    Adds a colorized console output sink to loguru.
+    Configures a colorized console logger using loguru.
+
 
     Args:
-        level (str): Logging level (DEBUG, INFO, WARNING, ERROR)
+        level (str): Logging level used for console output.
     """
     logger.add(
         sys.stderr,

--- a/logger_setup.py
+++ b/logger_setup.py
@@ -25,7 +25,7 @@ logger.add(
 
 def _handle_exception(exc_type, exc_value, exc_traceback):
     """
-    Handles uncaught exceptions registered via sys.excepthook and logs them using loguru.
+    Handles uncaught exceptions as a sys.excepthook handler and logs them using loguru.
     """
     if issubclass(exc_type, KeyboardInterrupt):
         sys.__excepthook__(exc_type, exc_value, exc_traceback)


### PR DESCRIPTION
## Summary
This PR standardizes docstrings across the codebase to follow the Google Python
Style Guide.

## Scope
- Improves docstring wording and consistency
- Clarifies argument descriptions
- Adds missing high-level docstrings where appropriate

## Out of scope
- No behavior changes
- No function contract or return-value changes

## Notes
Return-value semantics and failure modes (e.g. `None` returns in
`run_gh_command`) are intentionally not documented here. Defining explicit
function contracts is planned as a separate follow-up change.

This is a documentation-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified CLI and public function documentation and parameter descriptions for clearer usage.

* **Bug Fixes**
  * Prevent noisy logging on keyboard interrupt by exiting cleanly.
  * Improved logging for uncaught exceptions to include complete traceback information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->